### PR TITLE
Built in commandline options

### DIFF
--- a/source/config/scepsis.conf
+++ b/source/config/scepsis.conf
@@ -6,7 +6,7 @@
 #
 
 # Max number of micro code steps
-#microCodeSteps = 7
+#microCodeSteps = 16
 
 # Size of memory in bytes
 #memorySize = 65536


### PR DESCRIPTION
See issue #29, that stated:
- remove the GUI bloat and make it a command line tool like:
- SCEPSASM sourcefile [-o objectfile] [-l listfile]

This issue will hereby be solved.